### PR TITLE
Upgrade numpy for python 3.12 compatibility

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "build": {
+    "env": {
+      "VERCEL_PYTHON_VERSION": "3.11"
+    }
+  }
+}


### PR DESCRIPTION
Pin Vercel Python runtime to 3.11 via `vercel.json` to resolve `ModuleNotFoundError: No module named 'distutils'` during dependency installation.

This change explicitly sets the Python version for Vercel deployments to 3.11. This addresses build failures caused by the `distutils` module being removed in Python 3.12, which affects older dependencies during installation.

---
<a href="https://cursor.com/background-agent?bcId=bc-43093f3b-36c2-40c0-bf64-a0430ff6aabe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-43093f3b-36c2-40c0-bf64-a0430ff6aabe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

