### PR TITLE
Fix vercel invalid function runtime version

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,22 @@
 {
+  "version": 2,
   "buildCommand": "npm install && npm run build --prefix frontend && pip install -r requirements.txt",
   "outputDirectory": "frontend/dist",
   "framework": null,
-  "functions": {
-    "main.py": {
-      "runtime": "python3.11"
+  "builds": [
+    {
+      "src": "main.py",
+      "use": "@vercel/python"
     }
-  },
+  ],
+  "routes": [
+    {
+      "src": "/api/(.*)",
+      "dest": "main.py"
+    }
+  ],
   "env": {
-    "PYTHON_SETUP_REQUIRES": "setuptools>=68.0.0 wheel>=0.41.0"
+    "PYTHON_SETUP_REQUIRES": "setuptools>=68.0.0 wheel>=0.41.0",
+    "PYTHONPATH": "./"
   }
 }


### PR DESCRIPTION
Update `vercel.json` to fix Vercel build error due to invalid function runtime configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-6643d74b-faaf-456f-9859-6f2cc92c8cd5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6643d74b-faaf-456f-9859-6f2cc92c8cd5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

