### PR TITLE
Configure vercel for python deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,29 +1,18 @@
 {
   "version": 2,
-  "buildCommand": "cd frontend && npm install --legacy-peer-deps && npm run build",
-  "outputDirectory": "frontend/dist",
   "installCommand": "cd frontend && npm install --legacy-peer-deps",
+  "buildCommand": "cd frontend && npm run build",
+  "outputDirectory": "frontend/dist",
   "framework": null,
   "functions": {
-     "api/**/*.py": {
- 
-    "api/index.py": {
-       "runtime": "@vercel/python@3.12"
+    "api/**/*.py": {
+      "runtime": "@vercel/python@3.12"
     }
   },
   "rewrites": [
-     { "source": "/api/(.*)", "destination": "/api/index.py" },
+    { "source": "/api/(.*)", "destination": "/api/index.py" },
     { "source": "/(.*)", "destination": "/index.html" }
- 
-    {
-      "source": "/api/(.*)",
-      "destination": "/api/index.py"
-    },
-    {
-      "source": "/(.*)",
-      "destination": "/index.html"
-    }
-   ],
+  ],
   "env": {
     "PYTHONPATH": "./",
     "PYTHON_SETUP_REQUIRES": "setuptools>=68.0.0 wheel>=0.41.0"


### PR DESCRIPTION
Corrects Vercel configuration to resolve "unmatched-function-pattern" build error for Python functions.

The previous `vercel.json` had an invalid `functions` pattern (`main.py`) and duplicate/malformed rewrites, preventing Vercel from correctly identifying and deploying the Python API. This PR updates the `functions` pattern to `api/**/*.py` and cleans up the `rewrites` array.

---
<a href="https://cursor.com/background-agent?bcId=bc-2481c745-6b8a-4e62-9ddd-a0e5176234d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2481c745-6b8a-4e62-9ddd-a0e5176234d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

