### PR TITLE
Fix docker login and sarif upload

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,14 +32,14 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: ${{ env.DOCKER_USERNAME }}
-        password: ${{ env.DOCKER_TOKEN }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_TOKEN }}
 
     - name: Extract Metadata (tags, labels)
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}
+        images: ${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}
         tags: |
           type=ref,event=branch
           type=ref,event=pr
@@ -60,7 +60,7 @@ jobs:
     - name: Run Basic Container Test
       run: |
         echo "Testing the built image..."
-        docker run --rm --name test-container -d -p 8080:8000 ${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+        docker run --rm --name test-container -d -p 8080:8000 ${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:latest
         sleep 15
         echo "Container started successfully!"
         docker logs test-container
@@ -68,16 +68,18 @@ jobs:
         echo "Container test passed!"
 
     - name: Run Security Scan
+      id: trivy-scan
       uses: aquasecurity/trivy-action@master
+      continue-on-error: true
       with:
-        image-ref: ${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+        image-ref: ${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:latest
         format: 'sarif'
         output: 'trivy-results.sarif'
         exit-code: '0'
 
     - name: Upload Security Results
       uses: github/codeql-action/upload-sarif@v3
-      if: always()
+      if: always() && steps.trivy-scan.outcome == 'success' && hashFiles('trivy-results.sarif') != ''
       with:
         sarif_file: 'trivy-results.sarif'
 
@@ -85,21 +87,25 @@ jobs:
       run: |
         echo "## 🚀 Build Complete!" >> $GITHUB_STEP_SUMMARY
         echo "### 📦 Image Details:" >> $GITHUB_STEP_SUMMARY
-        echo "- **Repository**: \`${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Repository**: \`${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
         echo "- **Tags**: \`${{ steps.meta.outputs.tags }}\`" >> $GITHUB_STEP_SUMMARY
         echo "- **Build Time**: $(date)" >> $GITHUB_STEP_SUMMARY
         echo "- **Commit**: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
         echo "- **Branch**: \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### 🔒 Security:" >> $GITHUB_STEP_SUMMARY
-        echo "- Trivy security scan completed" >> $GITHUB_STEP_SUMMARY
-        echo "- Results uploaded to GitHub Security tab" >> $GITHUB_STEP_SUMMARY
+        if [ -f "trivy-results.sarif" ]; then
+          echo "- ✅ Trivy security scan completed successfully" >> $GITHUB_STEP_SUMMARY
+          echo "- Results uploaded to GitHub Security tab" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "- ⚠️ Trivy security scan failed or was skipped" >> $GITHUB_STEP_SUMMARY
+        fi
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### 🐳 Quick Run Commands:" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
         echo "# Pull and run the container" >> $GITHUB_STEP_SUMMARY
-        echo "docker pull ${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
-        echo "docker run -d -p 8000:8000 --name legal-dashboard ${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
+        echo "docker pull ${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
+        echo "docker run -d -p 8000:8000 --name legal-dashboard ${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "# Check container status" >> $GITHUB_STEP_SUMMARY
         echo "docker ps" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Correct Docker Hub credential access and add robust SARIF file generation/upload to CI workflow.

The Docker Hub login was failing because the workflow was incorrectly referencing credentials via `env` variables instead of `secrets`. This PR updates the workflow to use `secrets` directly. Additionally, it makes the Trivy SARIF file generation and upload more resilient by allowing Trivy to continue on error and only attempting to upload the SARIF file if it successfully exists.

---
<a href="https://cursor.com/background-agent?bcId=bc-15e65007-ceeb-43c3-b607-1aea5f5179aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-15e65007-ceeb-43c3-b607-1aea5f5179aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

