### PR TITLE
Validate vercel.json and use ignore/include

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -3,6 +3,10 @@
 .env
 .git/**
 .venv/**
+node_modules/**
+coverage/**
+dist/**
+.build/**
 tests/**
 *.md
 .gitignore

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,11 @@
   "outputDirectory": "frontend/dist",
   "functions": {
     "api/**/*.py": {
-      "runtime": "python3.11"
+      "runtime": "python3.11",
+      "includeFiles": [
+        "requirements.txt",
+        "python/resilient_proxy/**"
+      ]
     }
   },
   "rewrites": [


### PR DESCRIPTION
Migrate Vercel configuration to use `functions.includeFiles` and `.vercelignore` for file management.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ccaf5cf-f264-4b6d-9ede-08f726398b9f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ccaf5cf-f264-4b6d-9ede-08f726398b9f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

