### PR TITLE
Fix legal dashboard srupper project

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.115.0
+uvicorn[standard]>=0.30.0


### PR DESCRIPTION
Add a lightweight `api/requirements.txt` to fix Vercel deployment failures caused by excessive dependencies.

The Vercel build was failing because the Python serverless function attempted to install all packages from the repository-wide `requirements.txt`, which included large, compiled libraries. This led to deployment timeouts. By adding a minimal `api/requirements.txt` next to the function, Vercel's Python builder now installs only the necessary `fastapi` and `uvicorn` packages, significantly reducing build size and time.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5fae3bc-78f6-4549-a607-7e23b06a4bfa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5fae3bc-78f6-4549-a607-7e23b06a4bfa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

