### PR TITLE
Fix recording modal import build error

### DIFF
--- a/src/pages/Recording/Modal.tsx
+++ b/src/pages/Recording/Modal.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Simple reusable modal used by recording related pages.
+ * This component deliberately lives inside `src/pages/Recording` so it can be
+ * imported via `./pages/Recording/Modal` from within `App.tsx` or any other
+ * feature modules without updating legacy import paths that might still exist
+ * in deployment artifacts.
+ */
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="relative w-full max-w-md mx-4 bg-white rounded-lg shadow-lg dark:bg-gray-800">
+        {/* Close button */}
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close modal"
+          className="absolute top-3 right-3 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+
+        {/* Modal content */}
+        <div className="p-6">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;


### PR DESCRIPTION
Adds the missing `Modal` component to `src/pages/Recording/Modal.tsx` to resolve a critical build error.

The build was failing because `App.tsx` was trying to import a non-existent file. This PR creates the expected component at the specified path, allowing the build to succeed without modifying existing import statements.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9af4eaa-1ff3-43ad-b2f5-d441fc0a054f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e9af4eaa-1ff3-43ad-b2f5-d441fc0a054f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

